### PR TITLE
Fix permissions of read-only files

### DIFF
--- a/parse_redist.py
+++ b/parse_redist.py
@@ -26,6 +26,7 @@ if sys.version_info < tuple(map(int, minimum.split("."))):
 
 import argparse
 import os
+import stat
 import hashlib
 import json
 import re
@@ -92,6 +93,15 @@ def check_size(filename, size):
         print("	-> Expectation: " + size)
 
 
+def fix_permissions(directory):
+    """Fix for read-only files chmod u+w"""
+    for root, dirs, files in os.walk(directory):
+        for file in files:
+            filename = os.path.join(root, file)
+            octal = os.stat(filename)
+            os.chmod(filename, octal.st_mode | stat.S_IWRITE)
+
+
 def flatten_tree(src, dest, tag=None):
     """Merge hierarchy from multiple directories"""
     if tag:
@@ -100,8 +110,6 @@ def flatten_tree(src, dest, tag=None):
     try:
         shutil.copytree(src, dest, symlinks=1, dirs_exist_ok=1, ignore_dangling_symlinks=1)
     except FileExistsError:
-        pass
-    except OSError:
         pass
     shutil.rmtree(src)
 
@@ -250,7 +258,10 @@ def post_action(output_dir, collapse=True):
                 topdir = os.path.commonprefix(tarball.getnames())
                 tarball.extractall()
                 tarball.close()
+
                 print("  -> Extracted: " + topdir + "/")
+                fix_permissions(topdir)
+
                 if collapse:
                     flatdir = os.path.join(output_dir, platform)
                     flatten_tree(topdir, flatdir, binTag)
@@ -265,6 +276,8 @@ def post_action(output_dir, collapse=True):
                 zippy.close()
 
                 print("  -> Extracted: " + topdir)
+                fix_permissions(topdir)
+
                 if collapse:
                     flatdir = os.path.join(output_dir, platform)
                     flatten_tree(topdir, flatdir, binTag)

--- a/parse_redist.py
+++ b/parse_redist.py
@@ -128,6 +128,7 @@ def parse_artifact(
     if (
         retrieve
         and not os.path.exists(filename)
+        and not os.path.exists(full_path)
         and not os.path.exists(parent + filename)
         and not os.path.exists(pwd + filename)
     ):
@@ -139,6 +140,10 @@ def parse_artifact(
         print("  -> Found: " + filename)
         file_path = filename
         ARCHIVES[platform].append(filename)
+    elif os.path.exists(full_path):
+        file_path = full_path
+        print("  -> Found: " + file_path)
+        ARCHIVES[platform].append(file_path)
     elif os.path.exists(os.path.join(parent, filename)):
         file_path = os.path.join(parent, filename)
         print("  -> Found: " + file_path)


### PR DESCRIPTION
For some binary archive tarballs, the included `LICENSE` files are set to octal permissions `0444` which prevents the flatten stage from moving them due to permission denied. This change fixes #12 by adding u+w `0644` permissions.