### PR TITLE
fix(parse_redist): join pwd and filename when checking for cached arc…

### DIFF
--- a/parse_redist.py
+++ b/parse_redist.py
@@ -138,7 +138,7 @@ def parse_artifact(
         and not os.path.exists(filename)
         and not os.path.exists(full_path)
         and not os.path.exists(parent + filename)
-        and not os.path.exists(pwd + filename)
+        and not os.path.exists(os.path.join(pwd, filename))
     ):
         # Download archive
         fetch_file(full_path, filename)

--- a/tests/test_parse_redist.py
+++ b/tests/test_parse_redist.py
@@ -1,0 +1,87 @@
+import hashlib
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+# Make the repo root importable so we can load parse_redist directly.
+_repo_root = Path(__file__).resolve().parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+import parse_redist
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def test_parse_artifact_uses_pwd_path_join():
+    """Cached archive under <cwd>/<component>/<platform> must be found.
+
+    Regression for a path-join bug: the existence check concatenated
+    `pwd + filename` without a separator, so the cached archive was never
+    found and `fetch_file` was always invoked.
+    """
+    original_cwd = os.getcwd()
+    original_archives = parse_redist.ARCHIVES.copy()
+    fetch_calls = []
+
+    def fake_fetch(full_path, filename):
+        fetch_calls.append((full_path, filename))
+
+    original_fetch_file = parse_redist.fetch_file
+    parse_redist.fetch_file = fake_fetch
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        os.chdir(tmpdir)
+        parse_redist.ARCHIVES.clear()
+
+        component = "cuda_cccl"
+        platform = "linux-x86_64"
+        parse_redist.ARCHIVES[platform] = []
+        filename = "cccl-v1.tar.xz"
+        pwd = os.path.join(tmpdir, component, platform)
+        os.makedirs(pwd, exist_ok=True)
+        archive_path = os.path.join(pwd, filename)
+        archive_data = b"fake archive data"
+        with open(archive_path, "wb") as f:
+            f.write(archive_data)
+
+        size = len(archive_data)
+        checksum = _sha256(Path(archive_path))
+        manifest = {
+            component: {
+                platform: {
+                    "relative_path": "/redist/" + filename,
+                    "size": str(size),
+                    "sha256": checksum,
+                }
+            }
+        }
+        parent = "https://example.com"
+
+        parse_redist.parse_artifact(
+            parent,
+            manifest,
+            component,
+            platform,
+            retrieve=True,
+            integrity=True,
+            validate=True,
+        )
+
+        assert not fetch_calls, f"fetch_file was called unexpectedly: {fetch_calls}"
+        assert archive_path in parse_redist.ARCHIVES[platform]
+    finally:
+        parse_redist.fetch_file = original_fetch_file
+        parse_redist.ARCHIVES.clear()
+        parse_redist.ARCHIVES.update(original_archives)
+        os.chdir(original_cwd)
+        shutil.rmtree(tmpdir, ignore_errors=True)


### PR DESCRIPTION
…hives

## Summary

`parse_artifact()` probes several locations for an already-downloaded archive before fetching it over the network. One of those probes checks the per-component/platform directory (`<cwd>/<component>/<platform>/`), but the existence check concatenates `pwd` and `filename` without a path separator, so it never matches. The archive is therefore re-downloaded even when a valid local copy exists at that path.

## Root cause

```python
pwd = os.path.join(os.getcwd(), component, platform)

if (
    retrieve
    and not os.path.exists(filename)
    and not os.path.exists(full_path)
    and not os.path.exists(parent + filename)
    and not os.path.exists(pwd + filename)   # <- missing os.sep
):
    fetch_file(full_path, filename)
```

`pwd` has no trailing separator, so `pwd + filename` yields e.g. `/work/cuda_cccl/linux-x86_64cccl-v1.tar.xz`, which never exists. Every other probe of the same directory (the `elif` branch below) uses `os.path.join(pwd, filename)`, showing the intent.

## Fix

One-line change:

```python
and not os.path.exists(os.path.join(pwd, filename))
```

## Testing

No test suite exists in this repo, so a focused regression script was run with an ephemeral env (`uv run --python 3.12`): it places a fake archive at `os.path.join(cwd, component, platform)`, monkeypatches `fetch_file`, and calls `parse_artifact(retrieve=True)`.

- With the fix: PASS — existing file is found, no download attempted.
- With the fix stashed (unmodified `main`): FAIL — `fetch_file` is called, i.e. the archive is needlessly re-downloaded.

## Why existing tests missed it

The repo ships no tests for `parse_redist.py`; the bug is a silent redundant-download rather than a crash, so it is only observable by watching network fetches.